### PR TITLE
Walk up module call stack when using require_optional in dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var find_package_json = function(location) {
 
 // Find the package.json object of the module closest up the module call tree that contains name in that module's peerOptionalDependencies
 var find_package_json_with_name = function(name) {
-  // Walk the module call tree until we find a module containing name in its peerOptionalDependencies
+  // Walk up the module call tree until we find a module containing name in its peerOptionalDependencies
   var currentModule = module;
   var found = false;
   while (currentModule) {
@@ -101,7 +101,6 @@ var require_optional = function(name, options) {
 
   // Read the module file
   var dependentOnModule = JSON.parse(fs.readFileSync(f('%s/package.json', location)));
-  // console.log(dependentOnModule)
   // Get the version
   var version = dependentOnModule.version;
   // Validate if the found module satisfies the version id

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var path = require('path'),
 
 var exists = fs.existsSync || path.existsSync;
 
+// Find the location of a package.json file near or above the given location
 var find_package_json = function(location) {
   var found = false;
 
@@ -22,34 +23,52 @@ var find_package_json = function(location) {
   return location;
 }
 
+// Find the package.json object of the module closest up the module call tree that contains name in that module's peerOptionalDependencies
+var find_package_json_with_name = function(name) {
+  // Walk the module call tree until we find a module containing name in its peerOptionalDependencies
+  var currentModule = module;
+  var found = false;
+  while (currentModule) {
+    // Check currentModule has a package.json
+    location = currentModule.filename;
+    var location = find_package_json(location)
+    if (!location) {
+      currentModule = currentModule.parent;
+      continue;
+    }
+
+    // Read the package.json file
+    var object = JSON.parse(fs.readFileSync(f('%s/package.json', location)));
+    // Is the name defined by interal file references
+    var parts = name.split(/\//);
+
+    // Check whether this package.json contains peerOptionalDependencies containing the name we're searching for
+    if (!object.peerOptionalDependencies || (object.peerOptionalDependencies && !object.peerOptionalDependencies[parts[0]])) {
+      currentModule = currentModule.parent;
+      continue;
+    }
+    found = true;
+    break;
+  }
+
+  // Check whether name has been found in currentModule's peerOptionalDependencies
+  if (!found) {
+    throw new Error(f('no optional dependency [%s] defined in peerOptionalDependencies in any package.json', parts[0]));
+  }
+
+  return {
+    object: object,
+    parts: parts
+  }
+}
+
 var require_optional = function(name, options) {
   options = options || {};
   options.strict = typeof options.strict == 'boolean' ? options.strict : true;
 
-  // Current location
-  var location = __dirname;
-  // Check if we have a parent
-  if(module.parent) {
-    location = module.parent.filename;
-  }
-
-  // Locate this module's package.json file
-  var location = find_package_json(location);
-  if(!location) {
-    throw new Error('package.json can not be located');
-  }
-
-  // Read the package.json file
-  var object = JSON.parse(fs.readFileSync(f('%s/package.json', location)));
-  // Is the name defined by interal file references
-  var parts = name.split(/\//);
-
-  // Optional dependencies exist
-  if(!object.peerOptionalDependencies) {
-    throw new Error(f('no optional dependency [%s] defined in peerOptionalDependencies in package.json', parts[0]));
-  } else if(object.peerOptionalDependencies && !object.peerOptionalDependencies[parts[0]]) {
-    throw new Error(f('no optional dependency [%s] defined in peerOptionalDependencies in package.json', parts[0]));
-  }
+  var res = find_package_json_with_name(name)
+  var object = res.object;
+  var parts = res.parts;
 
   // Unpack the expected version
   var expectedVersions = object.peerOptionalDependencies[parts[0]];
@@ -82,6 +101,7 @@ var require_optional = function(name, options) {
 
   // Read the module file
   var dependentOnModule = JSON.parse(fs.readFileSync(f('%s/package.json', location)));
+  // console.log(dependentOnModule)
   // Get the version
   var version = dependentOnModule.version;
   // Validate if the found module satisfies the version id

--- a/test/nestedTest/index.js
+++ b/test/nestedTest/index.js
@@ -1,0 +1,8 @@
+var require_optional = require('../../')
+
+function findPackage(packageName) {
+  var pkg = require_optional(packageName);
+  return pkg;
+}
+
+module.exports.findPackage = findPackage

--- a/test/nestedTest/package.json
+++ b/test/nestedTest/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "nestedtest",
+  "version": "1.0.0",
+  "description": "A dummy package that facilitates testing that require_optional correctly walks up the module call stack",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Sebastian Hallum Clarke",
+  "license": "ISC"
+}

--- a/test/require_optional_tests.js
+++ b/test/require_optional_tests.js
@@ -1,5 +1,6 @@
 var assert = require('assert'),
-  require_optional = require('../');
+  require_optional = require('../'),
+  nestedTest = require('./nestedTest');
 
 describe('Require Optional', function() {
   describe('top level require', function() {
@@ -38,5 +39,21 @@ describe('Require Optional', function() {
       assert.equal(true, require_optional.exists('bson/lib/bson/long.js'));
       assert.equal(false, require_optional.exists('es6-promise2'));
     });
+  });
+
+  describe('require_optional inside dependencies', function() {
+    it('should correctly walk up module call stack searching for peerOptionalDependencies', function() {
+      assert.ok(nestedTest.findPackage('bson'))
+    });
+    it('should return null when a package is defined in top-level package.json but not installed', function() {
+      assert.equal(null, nestedTest.findPackage('es6-promise2'))
+    });
+    it('should error when searching for an optional dependency that is not defined in any ancestor package.json', function() {
+      try {
+        nestedTest.findPackage('bison')
+      } catch (err) {
+        assert.equal(err.message, 'no optional dependency [bison] defined in peerOptionalDependencies in any package.json')
+      }
+    })
   });
 });


### PR DESCRIPTION
This PR adds the ability for require_optional to walk up the module call tree when it is searching for where the given search module is listed in `peerOptionalDependencies`. Example use case below.

__TopLevel__ App
* List SecondLevelA as a regular dependency. It calls `require('second-level')`.
* Lists on MagicalUtility as a peerOptionalDependency.

__SecondLevel__ Package
* Lists require_optional as a regular dependency.  It calls `require('require_optional')`.
* Calls `require_optional('magical-utility')`.

With the changes in this PR, require_optional will now be able to resolve the call to optionally require MagicalUtility. It will walk up and look at TopLevel's `package.json` and find MagicalUtility listed there in `peerOptionalDependencies`.

These changes will allow us to optionally include Snappy in mongodb-core and enable support for wire protocol compression.