### PR TITLE
fix: Avoid infinite loop scenario for self-linked module parents

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,11 @@ var find_package_json = function(location) {
   return location;
 }
 
+// Get the parent module, or null if parent links itself
+var get_parent_module = function(module) {
+  return (module !== module.parent) ? module.parent : null;
+}
+
 // Find the package.json object of the module closest up the module call tree that contains name in that module's peerOptionalDependencies
 var find_package_json_with_name = function(name) {
   // Walk up the module call tree until we find a module containing name in its peerOptionalDependencies
@@ -33,7 +38,7 @@ var find_package_json_with_name = function(name) {
     location = currentModule.filename;
     var location = find_package_json(location)
     if (!location) {
-      currentModule = currentModule.parent;
+      currentModule = get_parent_module(currentModule);
       continue;
     }
 
@@ -44,7 +49,7 @@ var find_package_json_with_name = function(name) {
 
     // Check whether this package.json contains peerOptionalDependencies containing the name we're searching for
     if (!object.peerOptionalDependencies || (object.peerOptionalDependencies && !object.peerOptionalDependencies[parts[0]])) {
-      currentModule = currentModule.parent;
+      currentModule = get_parent_module(currentModule);
       continue;
     }
     found = true;


### PR DESCRIPTION
I ran into an infinite loop, under a big stack of dependencies in another project. Jest was testing something using mongodb, which required a bunch of different connection modules, which require_optional'd "snappy", which it searched up in the package.jsons for. Unfortunately the project's root-level package.json appeared to link itself as its own `parent`, which hangs the entire instance in an infinite loop. It continually reads the package.json, sees there's no `"peerOptionalDependencies"` in it for the module it's looking for, then reloads the same package.json and tries again.

This fix takes the safe approach and sets the `currentModule` to `null`, if its parent is itself. It's not necessary we know all the scenarios that can cause this, only that it did happen, so it should throw an exception. The current exception for when the `while (currentModule)` loop is done will now be thrown.