### PR TITLE
Fixing location to point path

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ var find_package_json_with_name = function(name) {
   var found = false;
   while (currentModule) {
     // Check currentModule has a package.json
-    location = currentModule.filename;
+    location = currentModule.filename.split('/');
+    location = location.pop().join('/');
     var location = find_package_json(location)
     if (!location) {
       currentModule = get_parent_module(currentModule);


### PR DESCRIPTION
`currentModule.filename` points to the entrypoint instead of the module path.
Fixes #3 